### PR TITLE
Updating coffee script version to 1.9.1 and reverting fix for 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "coffee-script": "1.9.0",
+    "coffee-script": "1.9.1",
     "lodash": "2.4.1",
     "require-all": "^1.0.0",
     "stack-filter": "^1.0.0"

--- a/test/unit/ContainerSpec.coffee
+++ b/test/unit/ContainerSpec.coffee
@@ -11,7 +11,7 @@ describe "injector - Container Management", ->
 
 
   it "addResolvableDependency", ->
-    @injector.addResolvableDependency "foo", (@bar)->
+    @injector.addResolvableDependency "foo", (bar)->
     dep = @injector.getDependency("foo")
     expect(dep.dependencies).to.deep.equal ["bar"]
     expect(dep.name).to.equal "foo"


### PR DESCRIPTION
All modules are being updated to use 1.9.1. Also reverting a hack in our tests related to 1.9.0.
