### PR TITLE
Deprecating pre node 4 version support and updating devDeps

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": ["es2015-loose"],
   "plugins": ["add-module-exports"],
+  "sourceMaps": "both",
   "retainLines": "true"
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,5 @@
 {
   "presets": ["es2015-loose"],
   "plugins": ["add-module-exports"],
-  "sourceMaps": "both",
   "retainLines": "true"
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
   "extends": "opentable",
   "env": {
     "node": true
+  },
+  "rules": {
+    "class-methods-use-this": 0
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 node_js:
-- '0.10'
-- '0.11'
-- '0.12'
 - '4'
-- '5'
 - '6'
 script: npm run build-and-test

--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ $ npm install
 $ npm test
 ```
 
+> Requires Node 4+ for dev tools, but we recommend using Node 6.
+
 ## Watch files and rebuild on change
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ The Spur Framework is a collection of commonly used Node.JS libraries used to cr
   * Ability to link injectors
   * Makes testing super easy
     * Ability to substitute dependencies in tests
-  * Resolution of dependencies by querying via regular expresion
+  * Resolution of dependencies by querying via regular expression
   * Clear error stack trace reporting
+  * Supports active Node versions in the [LTS Schedule](https://github.com/nodejs/LTS#lts-schedule). ([view current versions](.travis.yml))
 
 # What is inversion of control and why you should use it?
 
@@ -77,7 +78,7 @@ module.exports = function(){
     "nodeProcess" : process
   });
 
-  // register folders in your project to be autoinjected
+  // register folders in your project to be auto-injected
   ioc.registerFolders(__dirname, [
     "demo"
   ]);
@@ -93,7 +94,7 @@ Example of file that depends on an injectable dependency. This example shows the
 ```javascript
 module.exports = function(_){
     return _.map([1,2,3], function(num) {
-        return "Task " + num
+        return "Task " + num;
     });
 }
 ```
@@ -105,8 +106,8 @@ This example injects Tasks and console dependencies, both previously defined in 
 ```javascript
 module.exports = function(Tasks, console){
     return {
-        print:function(){
-            console.log(Tasks)
+        print: function(){
+          console.log(Tasks);
         }
     };
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/Injector.js",
   "jsnext:main": "./src/Injector",
   "scripts": {
-    "build": "babel src -d lib --source-maps",
+    "build": "babel src -d lib",
     "dev": "babel --watch src -d lib",
     "lint": "eslint .",
     "pretest": "npm run lint",
@@ -62,13 +62,13 @@
     "stack-filter": "^1.0.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.5.1",
+    "babel-cli": "^6.18.0",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-es2015": "^6.18.0",
     "babel-preset-es2015-loose": "^8.0.0",
     "chai": "^3.5.0",
     "eslint": "^3.13.1",
-    "eslint-config-opentable": "^4.0.0",
+    "eslint-config-opentable": "^6.0.0",
     "mocha": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,11 +65,10 @@
     "babel-cli": "^6.5.1",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.5.0",
-    "babel-preset-es2015-loose": "^7.0.0",
+    "babel-preset-es2015-loose": "^8.0.0",
     "chai": "^3.5.0",
-    "eslint": "^2.4.0",
+    "eslint": "^3.13.1",
     "eslint-config-opentable": "^4.0.0",
-    "eslint-plugin-import": "^1.8.1",
-    "mocha": "^2.4.5"
+    "mocha": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test-integration": "babel-node --debug node_modules/mocha/bin/_mocha ./test/integration/",
     "test": "npm run test-unit && npm run test-integration",
     "build-and-test": "npm run build && npm test",
-    "preversion": "npm run build-and-test"
+    "preversion": "npm run build-and-test",
+    "prepublish": "npm run test"
   },
   "author": {
     "name": "Agustin Colchado",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/Injector.js",
   "jsnext:main": "./src/Injector",
   "scripts": {
-    "build": "babel src -d lib",
+    "build": "babel src -d lib --source-maps",
     "dev": "babel --watch src -d lib",
     "lint": "eslint .",
     "pretest": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-regenerator": "6.16.1",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-es2015-loose": "^8.0.0",
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "chai": "^3.5.0",
     "eslint": "^3.13.1",
     "eslint-config-opentable": "^6.0.0",
+    "eslint-plugin-import": "^2.2.0",
     "mocha": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,14 +5,16 @@
   "main": "lib/Injector.js",
   "jsnext:main": "./src/Injector",
   "scripts": {
-    "build": "babel src -d lib --source-maps",
-    "dev": "babel --watch src -d lib",
+    "clean": "rm -rf lib/",
+    "build": "npm run clean && babel src -d lib --source-maps",
+    "dev": "npm run clean && babel --watch src -d lib",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test-unit": "babel-node --debug node_modules/mocha/bin/_mocha ./test/unit/",
     "test-integration": "babel-node --debug node_modules/mocha/bin/_mocha ./test/integration/",
     "test": "npm run test-unit && npm run test-integration",
-    "build-and-test": "npm run build && npm test"
+    "build-and-test": "npm run build && npm test",
+    "preversion": "npm run build-and-test"
   },
   "author": {
     "name": "Agustin Colchado",

--- a/src/DependencyManagement.js
+++ b/src/DependencyManagement.js
@@ -15,7 +15,7 @@ export default {
 
   injectAndReturn(deps) {
     let resolvedDeps = null;
-    this.inject($injector => {
+    this.inject(($injector) => {
       resolvedDeps = deps instanceof RegExp
         ? $injector.getRegex(deps)
         : $injector.getMap(deps);

--- a/src/DependencyResolver.js
+++ b/src/DependencyResolver.js
@@ -1,6 +1,6 @@
-import CallChain from './CallChain';
 import _ from 'lodash';
 import stackFilter from 'stack-filter';
+import CallChain from './CallChain';
 
 class DependencyError {
   constructor(callChain, error, errorObject) {
@@ -86,9 +86,9 @@ class DependencyResolver {
 
   resolveRegex(regex) {
     const deps = _.keys(this.container.dependencies)
-      .filter((key) =>
-        regex.test(key) && key !== '$injector' && key !== this.container.privateInjectorName()
-      );
+      .filter((key) => { // eslint-disable-line
+        return regex.test(key) && key !== '$injector' && key !== this.container.privateInjectorName();
+      });
     return this.resolveMap(deps);
   }
 

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -15,7 +15,7 @@ class Level {
   }
 
   log(...args) {
-    // eslint-disable-next-line no-console
+    // eslint-disable-next-line no-console, prefer-spread
     return console.log.apply(console, [this.ascii].concat(args));
   }
 }
@@ -35,12 +35,12 @@ class Logger {
   }
 
   static create() {
-    return new Logger;
+    return new Logger();
   }
 
   addLoggingMethods() {
     _.each(LEVELS, (value, name) => {
-      if (LEVELS.hasOwnProperty(name)) {
+      if (Object.prototype.hasOwnProperty.call(LEVELS, name)) {
         this[name] = LEVELS[name].log;
       }
     });

--- a/src/RegistrationManagement.js
+++ b/src/RegistrationManagement.js
@@ -4,6 +4,10 @@ import _ from 'lodash';
 
 const rfileFilter = /(.+)\.(js|json|coffee)$/;
 
+const hasOwnProp = function (source, propertyName) {
+  return Object.prototype.hasOwnProperty.call(source, propertyName);
+};
+
 export default {
   registerFolder(rootDir, dir) {
     const dirname = path.resolve(rootDir, dir);
@@ -17,7 +21,7 @@ export default {
 
   registerLibMap(libs) {
     _.each(libs, (value, name) => {
-      if (libs.hasOwnProperty(name)) {
+      if (hasOwnProp(libs, name)) {
         const lib = libs[name];
         if (_.isFunction(lib)) {
           this.addResolvableDependency(name, lib);
@@ -30,7 +34,7 @@ export default {
   },
 
   registerFolders(rootDir, dirs) {
-    _.each(dirs, (dir) => this.registerFolder(rootDir, dir));
+    _.each(dirs, dir => this.registerFolder(rootDir, dir));
     return this;
   },
 
@@ -40,7 +44,7 @@ export default {
     );
 
     _.each(libraries, (value, name) => {
-      if (libraries.hasOwnProperty(name)) {
+      if (hasOwnProp(libraries, name)) {
         const lib = libraries[name];
         this.addDependency(name, require(lib)); // eslint-disable-line global-require
       }
@@ -50,7 +54,7 @@ export default {
 
   registerDependencies(dependencies) {
     _.each(dependencies, (value, name) => {
-      if (dependencies.hasOwnProperty(name)) {
+      if (hasOwnProp(dependencies, name)) {
         const lib = dependencies[name];
         this.addDependency(name, lib);
       }

--- a/src/Util.js
+++ b/src/Util.js
@@ -15,4 +15,4 @@ class Util {
   }
 }
 
-export default new Util;
+export default new Util();

--- a/test/globals.js
+++ b/test/globals.js
@@ -1,5 +1,8 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
 global.assert = require('assert');
 global.chai = require('chai');
+
 global.expect = global.chai.expect;
 process.env.NODE_ENV = 'test';
 

--- a/test/unit/ContainerSpec.js
+++ b/test/unit/ContainerSpec.js
@@ -12,7 +12,7 @@ describe('injector - Container Management', () => {
   });
 
   it('addResolvableDependency', function () {
-    this.injector.addResolvableDependency('foo', bar => {});
+    this.injector.addResolvableDependency('foo', (bar) => {});
     const dep = this.injector.getDependency('foo');
     expect(dep.dependencies).to.deep.equal(['bar']);
     expect(dep.name).to.equal('foo');
@@ -22,13 +22,13 @@ describe('injector - Container Management', () => {
   it('inject', function () {
     this.injector.addResolvableDependency('foo', (bar, punct, _) => `${bar} world${punct}${_.VERSION}`);
     this.injector.addResolvableDependency('bar', error => 'hi');
-    this.injector.addResolvableDependency('error', error1 => {});
-    this.injector.addResolvableDependency('error1', error2 => {}).addResolvableDependency('error2', error3 => {});
+    this.injector.addResolvableDependency('error', (error1) => {});
+    this.injector.addResolvableDependency('error1', (error2) => {}).addResolvableDependency('error2', (error3) => {});
     this.injector.addResolvableDependency('error3', (exception, cyclic, missing) => {});
     this.injector.addResolvableDependency('exception', () => {
       throw new Error('Oh no');
     });
-    this.injector.addResolvableDependency('cyclic', error => {});
+    this.injector.addResolvableDependency('cyclic', (error) => {});
     this.injector.addResolvableDependency('missing', (nothing, $injector) => {});
     this.injector.addDependency('punct', '!');
     this.injector.addDependency('_', require('lodash')); // eslint-disable-line global-require

--- a/test/unit/InjectorSpec.js
+++ b/test/unit/InjectorSpec.js
@@ -9,9 +9,9 @@ describe('Injector', () => {
 
   it('inject', function () {
     this.injector.registerFolders(__dirname, ['../fixtures']);
-    this.injector.inject((House) =>
-      expect(House).to.equal('House with Pitched Roof and Barn Doors and Double GlazedWindows and Long Garden')
-    );
+    this.injector.inject((House) => {
+      expect(House).to.equal('House with Pitched Roof and Barn Doors and Double GlazedWindows and Long Garden');
+    });
   });
 
   it('multi-injector', function () {


### PR DESCRIPTION

* Removing Node 0.10, 0.11, 0.12, and 5 from `.travis.yml` to only run tests on supported LTS versions
* Updating devDependencies
* Fixing code related to updating the version of `eslint-config-opentable` which had a few small changes to the syntax rules
* Adding `"babel-plugin-transform-regenerator": "6.16.1"` to resolve the build issue