### PR TITLE
Renaming from Util to FunctionArgumentsParser and adding tests

### DIFF
--- a/src/Dependency.js
+++ b/src/Dependency.js
@@ -1,4 +1,4 @@
-const Util = require('./Util');
+const FunctionArgumentsParser = require('./FunctionArgumentsParser');
 
 class Dependency {
   constructor(name) {
@@ -8,7 +8,7 @@ class Dependency {
   static resolvableDependency(name, dependency) {
     const dep = new Dependency(name);
     dep.fn = dependency;
-    dep.dependencies = Util.parseDependencies(dependency);
+    dep.dependencies = FunctionArgumentsParser.parse(dependency);
     return dep;
   }
 

--- a/src/FunctionArgumentsParser.js
+++ b/src/FunctionArgumentsParser.js
@@ -7,7 +7,8 @@ const rfunction = /function\s+\w*\s*\((.*?)\)/;
 const rcomma = /\s*,\s*/;
 
 class Util {
-  parseDependencies(fn) {
+
+  parse(fn) {
     const params = fn.toString()
       .replace(rnewline, ' ')
       .replace(rat, '')
@@ -15,6 +16,7 @@ class Util {
 
     return _compact(_map(params, (p) => p.trim()));
   }
+
 }
 
 module.exports = new Util();

--- a/test/unit/FunctionArgumentsParserSpec.js
+++ b/test/unit/FunctionArgumentsParserSpec.js
@@ -1,0 +1,76 @@
+const FunctionArgumentsParser = require('../../src/FunctionArgumentsParser');
+
+describe('FunctionArgumentsParser', () => {
+
+  const expectFunctionArgs = (fn, expected) => {
+    const result = FunctionArgumentsParser.parse(fn);
+    expect(result).to.deep.equal(expected);
+  };
+
+  describe('Function args', () => {
+
+    it('in a single line', () => {
+      const fn = function (dep1, dep2, dep3) { return dep1; };
+      expectFunctionArgs(fn, ['dep1', 'dep2', 'dep3']);
+    });
+
+    it('with no arguments', () => {
+      const fn = function () {
+      };
+
+      expectFunctionArgs(fn, []);
+    });
+
+    it('with only one argument', () => {
+      const fn = function (dep1) {
+        return dep1;
+      };
+
+      expectFunctionArgs(fn, ['dep1']);
+    });
+
+    it('with space after function', () => {
+      const fn = function (dep1, dep2, dep3) {
+        return dep1;
+      };
+
+      expectFunctionArgs(fn, ['dep1', 'dep2', 'dep3']);
+    });
+
+    it('with tab/multiple spaces after function', () => {
+      const fn = function   (dep1, dep2, dep3) {
+        return dep1;
+      };
+
+      expectFunctionArgs(fn, ['dep1', 'dep2', 'dep3']);
+    });
+
+    it('with space after function', () => {
+      const fn = function (dep1, dep2, dep3) {
+        return dep1;
+      };
+
+      expectFunctionArgs(fn, ['dep1', 'dep2', 'dep3']);
+    });
+
+    it('with new lines between arguements', () => {
+      const fn = function (dep1,
+        dep2,
+        dep3) {
+        return dep1;
+      };
+
+      expectFunctionArgs(fn, ['dep1', 'dep2', 'dep3']);
+    });
+
+    it('with no space between arguements', () => {
+      const fn = function(dep1,dep2,dep3) {
+        return dep1;
+      };
+
+      expectFunctionArgs(fn, ['dep1', 'dep2', 'dep3']);
+    });
+
+  });
+
+});


### PR DESCRIPTION
The original name of Util didn't make too much sense for this class that did just one thing.

Added some generic unit tests to make testing of this simple util clear and verbose.

This is prep for support for arrow functions requested int #37 