### PR TITLE
Adding arrow function support by porting functionality from Angular

### DIFF
--- a/test/unit/FunctionArgumentsParserSpec.js
+++ b/test/unit/FunctionArgumentsParserSpec.js
@@ -73,4 +73,68 @@ describe('FunctionArgumentsParser', () => {
 
   });
 
+  describe('Arrow function args', () => {
+
+    it('in a single line', () => {
+      const fn = (dep1, dep2, dep3) => { return dep1; };
+      expectFunctionArgs(fn, ['dep1', 'dep2', 'dep3']);
+    });
+
+    it('with no arguments', () => {
+      const fn = () => {};
+      expectFunctionArgs(fn, []);
+    });
+
+    it('with only one argument', () => {
+      const fn = (dep1) => {
+        return dep1;
+      };
+
+      expectFunctionArgs(fn, ['dep1']);
+    });
+
+    it('with space after function', () => {
+      const fn = (dep1, dep2, dep3) => {
+        return dep1;
+      };
+
+      expectFunctionArgs(fn, ['dep1', 'dep2', 'dep3']);
+    });
+
+    it('with tab/multiple spaces after function', () => {
+      const fn = (dep1, dep2, dep3)     => {
+        return dep1;
+      };
+
+      expectFunctionArgs(fn, ['dep1', 'dep2', 'dep3']);
+    });
+
+    it('with space after function', () => {
+      const fn = (dep1, dep2, dep3) => {
+        return dep1;
+      };
+
+      expectFunctionArgs(fn, ['dep1', 'dep2', 'dep3']);
+    });
+
+    it('with new lines between arguements', () => {
+      const fn = (dep1,
+        dep2,
+        dep3) => {
+        return dep1;
+      };
+
+      expectFunctionArgs(fn, ['dep1', 'dep2', 'dep3']);
+    });
+
+    it('with no space between arguements', () => {
+      const fn = (dep1,dep2,dep3)=> {
+        return dep1;
+      };
+
+      expectFunctionArgs(fn, ['dep1', 'dep2', 'dep3']);
+    });
+
+  });
+
 });


### PR DESCRIPTION
The original implementation was derived from the angular injector. This updates the functionality from the latest injector: https://github.com/angular/angular.js/blob/master/src/auto/injector.js#L66-L126

Addresses issue #37: https://github.com/opentable/spur-ioc/issues/37

@ssetem and @wesww Mind reviewing for me? Thanks