### PR TITLE
Removing the cleanStack call to make some errors in async calls more accurate

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,18 +57,18 @@
     "lodash.bindall": "^4.4.0",
     "lodash.compact": "^3.0.1",
     "lodash.foreach": "^4.5.0",
-    "lodash.isfunction": "^3.0.8",
+    "lodash.isfunction": "^3.0.9",
     "lodash.isobject": "^3.0.2",
     "lodash.keys": "^4.2.0",
     "lodash.map": "^4.6.0",
-    "require-all": "^2.0.0",
+    "require-all": "^2.2.0",
     "stack-filter": "^1.0.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "eslint": "^4.11.0",
-    "eslint-plugin-node": "^5.2.1",
-    "mocha": "^4.0.1",
-    "sinon": "^4.1.2"
+    "eslint": "^4.18.2",
+    "eslint-plugin-node": "^6.0.1",
+    "mocha": "^5.0.4",
+    "sinon": "^4.4.6"
   }
 }

--- a/src/DependencyResolver.js
+++ b/src/DependencyResolver.js
@@ -146,7 +146,6 @@ class DependencyResolver {
         }
         dep.instance = dep.fn.apply(null, instances);
       } catch (error) {
-        this.cleanStack(error);
         this.errors.push(DependencyError.exception(callChain, error));
       }
 
@@ -155,10 +154,6 @@ class DependencyResolver {
 
     this.errors.push(DependencyError.missingDependency(callChain));
     return null;
-  }
-
-  cleanStack(e) {
-    return (e.stack = `\t${this.stackFilter.filter(e.stack).join('\n\t')}`); // eslint-disable-line no-param-reassign
   }
 
   printErrors() {


### PR DESCRIPTION
This call is no longer needed. In some cases it's hiding the detail of the errors being thrown from dependencies. This was helpful when the code was writing in coffee, but with es it's no longer needed.

Also updates the dev dependencies.

Closes #38 