### PR TITLE
Resolving the security warning because of the version

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "eslint": "^5.3.0",
+    "eslint": "^5.16.0",
     "eslint-plugin-node": "^7.0.1",
     "mocha": "^5.2.0",
     "sinon": "^6.1.5"


### PR DESCRIPTION
No deploy needed yet due to it being a test dependency.