### PR TITLE
Adds the ability to read the typescript files

### DIFF
--- a/src/FileFilterExpression.js
+++ b/src/FileFilterExpression.js
@@ -1,0 +1,12 @@
+/*
+The addition of ts (typescript) file registration is only meant to allow the
+registration of the file itself. It doesn't guarantee full compilation but it
+expects that you have that handled with the use of something like on your end.
+
+TypeScript is not officially supported, but will be available through a
+beta/release candidate version.
+*/
+
+const expression = /(.+)\.(js|ts|json)$/;
+
+module.exports = expression;

--- a/src/RegistrationManagement.js
+++ b/src/RegistrationManagement.js
@@ -4,7 +4,7 @@ const _forEach = require('lodash.foreach');
 const _isFunction = require('lodash.isfunction');
 const _isObject = require('lodash.isobject');
 
-const rfileFilter = /(.+)\.(js|json)$/;
+const fileFilterExpression = require('./FileFilterExpression');
 
 const hasOwnProp = function (source, propertyName) {
   return Object.prototype.hasOwnProperty.call(source, propertyName);
@@ -15,7 +15,7 @@ module.exports = {
     const dirname = path.resolve(rootDir, dir);
     const libs = requireAll({
       dirname,
-      filter: rfileFilter
+      filter: fileFilterExpression
     });
     this.registerLibMap(libs);
     return this;

--- a/test/unit/FileFilterExpressionSpec.js
+++ b/test/unit/FileFilterExpressionSpec.js
@@ -1,0 +1,39 @@
+const subject = require('../../src/FileFilterExpression');
+
+describe('FileFilterExpression tests', function () {
+
+  it('should match a js file path', () => {
+    const path1 = 'src/some/path/FileFilterExpression.js';
+    const path2 = 'src\\somepath\\FileFilterExpression.js';
+
+    expect(subject.test(path1)).to.be.true;
+    expect(subject.test(path2)).to.be.true;
+  });
+
+  it('should match a json file path', () => {
+    const path1 = 'src/some/path/FileFilterExpression.json';
+    const path2 = 'src\\somepath\\FileFilterExpression.json';
+
+    expect(subject.test(path1)).to.be.true;
+    expect(subject.test(path2)).to.be.true;
+  });
+
+  it('should match a ts file path', () => {
+    const path1 = 'src/some/path/FileFilterExpression.ts';
+    const path2 = 'src\\somepath\\FileFilterExpression.ts';
+
+    expect(subject.test(path1)).to.be.true;
+    expect(subject.test(path2)).to.be.true;
+  });
+
+  it('should not match partial matches', () => {
+    const path1 = 'src/some/path/FileFilterExpression.js2';
+    const path2 = 'src/some/path/FileFilterExpression.json2';
+    const path3 = 'src/some/path/FileFilterExpression.ts2';
+
+    expect(subject.test(path1)).to.be.false;
+    expect(subject.test(path2)).to.be.false;
+    expect(subject.test(path3)).to.be.false;
+  });
+
+});


### PR DESCRIPTION
This addition is not meant to be full support of typescript from the library. It's meant to allow the reading of the files in the case you are looking to use TS files and are responsible for the transpilation/compilation of those files.

We are experimenting adding this to allow us to use ts files with ts-jest and other tooling in our tests and source files. The compilation is happening locally and doesn't depend on the package having full support for a build pipeline.

This will be published a major version so that those who may have .ts files won't have a break in their dev flow but once it's promoted out of release candidate, it will have proper documentation if we opt to keep the support.