### PR TITLE
Fixes test expect references to match Jest and cleans out noise

### DIFF
--- a/test/unit/Container.spec.js
+++ b/test/unit/Container.spec.js
@@ -10,12 +10,12 @@ describe('injector - Container Management', function () {
     const dep = this.injector.getDependency('foo');
     expect(dep.dependencies).toEqual(['bar']);
     expect(dep.name).toBe('foo');
-    this.injector.addResolvableDependency('foo', (bar) => { console.log(bar); });
+    this.injector.addResolvableDependency('foo', (bar) => { console.debug(bar); });
   });
 
   it('inject', () => {
 
-    this.injector.addResolvableDependency('foo', (bar, punct, _) => {
+    this.injector.addResolvableDependency('foo', (bar, punct) => {
       return `${bar} world${punct}`;
     });
 
@@ -51,7 +51,7 @@ describe('injector - Container Management', function () {
     this.injector.addDependency('punct', '!');
 
     expect(() => this.injector.inject((foo) => {
-      console.log(foo);
+      console.debug(foo);
     }))
     .toThrow('Resolver encountered errors');
   });

--- a/test/unit/Injector.spec.js
+++ b/test/unit/Injector.spec.js
@@ -72,11 +72,10 @@ describe('Injector', function () {
     DependencyResolver.prototype.throwError = () => {};
 
     this.injector1.inject(($injector) => {
-      expect($injector.get('missing')).to.equal(null);
+      expect($injector.get('missing')).toBeNull();
     });
 
     const error = this.injector1.resolver.errors[0];
-    console.log(error);
 
     expect(error.error).toBe('Missing Dependency');
     expect(error.callChain.getPath()).toBe('$$injector1 -> $injector -> missing');
@@ -92,19 +91,19 @@ describe('Injector', function () {
 
   it('dont allow async use of $injector', (done) => {
     this.injector.registerDependencies({
-      _: 'lodash',
-      chai: 'chai'
+      mockDep1: 'mockDep1raw',
+      mockDep2: 'mockDep2raw'
     });
 
     this.injector.addResolvableDependency('foo', ($injector) => {
       setTimeout(() => {
-        expect(() => $injector.get('chai')).toThrow('cannot use $injector.get(\'chai\') asynchronously');
+        expect(() => $injector.get('mockDep1raw')).toThrow('cannot use $injector.get(\'mockDep1raw\') asynchronously');
         expect(() => $injector.getRegex(/.+/)).toThrow('cannot use $injector.getRegex(/.+/) asynchronously');
         done();
       }, 0);
     });
 
-    this.injector.inject((_, chai, $injector, foo) => {});
+    this.injector.inject((mockDep1, mockDep2, $injector, foo) => {});
   });
 
   describe('ignored dependencies', () => {
@@ -157,8 +156,8 @@ describe('Injector', function () {
         this.injector.registerDependencies({ a: replacementDep });
 
         this.injector.inject((a) => {
-          expect(a).to.equal(replacementDep);
-          expect(a()).to.be.eq('updated');
+          expect(a).toEqual(replacementDep);
+          expect(a()).toBe('updated');
         });
       });
 


### PR DESCRIPTION

- Switches some console logs to debugs to so they can be identified as debug info
- removes _ (lodash) references no longer in the repo. This was producing noisy warnings in the tests
- Fixes missed assertions from chai to jest