### PR TITLE
refactor(colors): Removal of chalk coloring messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "chalk": "4.1.2",
         "lodash.assign": "4.2.0",
         "lodash.bindall": "4.4.0",
         "lodash.compact": "3.0.1",
@@ -1378,6 +1377,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1631,6 +1631,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1706,6 +1707,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1716,7 +1718,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2325,6 +2328,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4158,6 +4162,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "url": "git://github.com/opentable/spur-ioc.git"
   },
   "dependencies": {
-    "chalk": "4.1.2",
     "lodash.assign": "4.2.0",
     "lodash.bindall": "4.4.0",
     "lodash.compact": "3.0.1",

--- a/src/CallChain.js
+++ b/src/CallChain.js
@@ -1,5 +1,3 @@
-const chalk = require('chalk');
-
 class CallChain {
   constructor(name, parent) {
     this.name = name;
@@ -27,7 +25,7 @@ class CallChain {
   }
 
   getHighlightedName() {
-    return chalk.yellow(this.name);
+    return this.name;
   }
 
   getPath(highlight) {

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,6 +1,5 @@
 const _bindAll = require('lodash.bindall');
 const _forEach = require('lodash.foreach');
-const chalk = require('chalk');
 
 class Level {
   constructor(level, name, ascii, exit = false) {
@@ -21,12 +20,12 @@ class Level {
 }
 
 const LEVELS = {
-  fatal: Level.create(0, 'FATAL', chalk.black.bgRed('FATAL'), true),
-  error: Level.create(1, 'Error', chalk.red('ERROR')),
-  warn: Level.create(2, 'WARNING', chalk.yellow('WARNING')),
-  info: Level.create(3, 'INFO', chalk.green('INFO')),
-  debug: Level.create(4, 'DEBUG', chalk.reset('DEBUG')),
-  trace: Level.create(5, 'TRACE', chalk.white('TRACE'))
+  fatal: Level.create(0, 'FATAL', 'FATAL', true),
+  error: Level.create(1, 'Error', 'ERROR'),
+  warn: Level.create(2, 'WARNING', 'WARNING'),
+  info: Level.create(3, 'INFO', 'INFO'),
+  debug: Level.create(4, 'DEBUG', 'DEBUG'),
+  trace: Level.create(5, 'TRACE', 'TRACE')
 };
 
 class Logger {


### PR DESCRIPTION
The colorization of these messages do not add anything substantial to the logs unless they are running locally.

Removing it does however helps make this package more secure. There has been a few security concerns that chalk has exposed this framework to because of the low maintenance effort.

While spur-ioc and all other spur-packages will be going into maintenance mode, we are actively reducing any change that a new security concern can be discovered down the road due to a dependency.

If you want to see the colors, you can stick to the previous version of spur-ioc.