### PR TITLE
refactor(lodash): Removes most of the lodash dependencies in favor of native js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,6 @@
       "dependencies": {
         "lodash.assign": "4.2.0",
         "lodash.bindall": "4.4.0",
-        "lodash.compact": "3.0.1",
-        "lodash.foreach": "4.5.0",
-        "lodash.get": "4.4.2",
-        "lodash.isfunction": "3.0.9",
-        "lodash.isobject": "3.0.2",
-        "lodash.keys": "4.2.0",
-        "lodash.map": "4.6.0",
         "require-all": "3.0.0"
       },
       "devDependencies": {
@@ -3345,41 +3338,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.bindall/-/lodash.bindall-4.4.0.tgz",
       "integrity": "sha512-NQ+QvFohS2gPbWpyLfyuiF0ZQA3TTaJ+n0XDID5jwtMZBKE32gN5vSyy7xBVsqvJkvT/UY9dvHXIk9tZmBVF3g=="
-    },
-    "node_modules/lodash.compact": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.compact/-/lodash.compact-3.0.1.tgz",
-      "integrity": "sha512-2ozeiPi+5eBXW1CLtzjk8XQFhQOEMwwfxblqeq6EGyTxZJ1bPATqilY0e6g2SLQpP4KuMeuioBhEnWz5Pr7ICQ=="
-    },
-    "node_modules/lodash.foreach": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ=="
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-    },
-    "node_modules/lodash.isfunction": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
-    },
-    "node_modules/lodash.isobject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA=="
-    },
-    "node_modules/lodash.keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-      "integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ=="
-    },
-    "node_modules/lodash.map": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spur-ioc",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spur-ioc",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "lodash.assign": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -52,13 +52,6 @@
   "dependencies": {
     "lodash.assign": "4.2.0",
     "lodash.bindall": "4.4.0",
-    "lodash.compact": "3.0.1",
-    "lodash.foreach": "4.5.0",
-    "lodash.get": "4.4.2",
-    "lodash.isfunction": "3.0.9",
-    "lodash.isobject": "3.0.2",
-    "lodash.keys": "4.2.0",
-    "lodash.map": "4.6.0",
     "require-all": "3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spur-ioc",
   "description": "Dependency Injection library for Node.js",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "./src/Injector",
   "scripts": {
     "lint": "eslint .",

--- a/src/ContainerManagement.js
+++ b/src/ContainerManagement.js
@@ -1,20 +1,19 @@
-const _forEach = require('lodash.foreach');
-const _get = require('lodash.get');
-const _isFunction = require('lodash.isfunction');
-const _isObject = require('lodash.isobject');
 const Dependency = require('./Dependency');
+const Utils = require('./Utils');
 
 const rall = /.+/;
 
 module.exports = {
 
   getDependencySourceHint(dependency) {
-    if (_isFunction(dependency)) {
-      return _get(dependency, 'name') || '<anonymous function>';
+    if (Utils.isFunction(dependency)) {
+      return dependency.name || '<anonymous function>';
     }
 
-    if (_isObject(dependency)) {
-      return _get(dependency, 'constructor.name') || '<object>';
+    if (Utils.isObject(dependency)) {
+      return (dependency.constructor && dependency.constructor.name)
+        ? dependency.constructor.name
+        : '<object>';
     }
 
     return `<${typeof dependency}>`;
@@ -74,13 +73,18 @@ module.exports = {
   },
 
   shouldIgnoreDependency(dependency) {
-    return Boolean(_get(dependency, 'spurIocIgnore', false));
+    const spurIocIgnore = (dependency && dependency.spurIocIgnore)
+      ? dependency.spurIocIgnore
+      : false;
+
+    return Boolean(spurIocIgnore);
   },
 
   merge(otherInjector, suppressWarning = false) {
-    const dependencies = otherInjector.dependencies;
+    const dependencies = otherInjector.dependencies || {};
+    const names = Object.keys(dependencies) || [];
 
-    _forEach(dependencies, (value, name) => {
+    names.forEach((name) => {
       const dependency = dependencies[name];
       this.addConstructedDependency(name, dependency, suppressWarning);
     });

--- a/src/DependencyResolver.js
+++ b/src/DependencyResolver.js
@@ -1,5 +1,4 @@
 const _bindAll = require('lodash.bindall');
-const _keys = require('lodash.keys');
 const CallChain = require('./CallChain');
 
 class DependencyError {
@@ -82,7 +81,7 @@ class DependencyResolver {
   }
 
   resolveRegex(regex) {
-    const deps = _keys(this.container.dependencies)
+    const deps = (Object.keys(this.container.dependencies) || [])
       .filter((key) => { // eslint-disable-line
         return regex.test(key) && key !== '$injector' && key !== this.container.privateInjectorName();
       });

--- a/src/FunctionArgumentsParser.js
+++ b/src/FunctionArgumentsParser.js
@@ -1,6 +1,3 @@
-const _map = require('lodash.map');
-const _compact = require('lodash.compact');
-
 const NEWLINE = /\n/g;
 const AT = /_at_/g;
 const ARROW_ARG = /^([^(]+?)=>/;
@@ -21,11 +18,14 @@ class FunctionArgumentsParser {
 
     argsDeclaration[1].split(FN_ARG_SPLIT).forEach(function (arg) {
       arg.replace(FN_ARG, function(name) {
-        args.push(name);
+        const cleanName = (name || '').trim();
+        if (cleanName.length > 0) {
+          args.push(cleanName);
+        }
       });
     });
 
-    return _compact(_map(args, (p) => p.trim()));
+    return args;
   }
 
   extractArgs(fn) {

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,5 +1,4 @@
 const _bindAll = require('lodash.bindall');
-const _forEach = require('lodash.foreach');
 
 class Level {
   constructor(level, name, ascii, exit = false) {
@@ -38,7 +37,8 @@ class Logger {
   }
 
   addLoggingMethods() {
-    _forEach(LEVELS, (value, name) => {
+    const names = Object.keys(LEVELS) || [];
+    names.forEach((name) => {
       if (Object.prototype.hasOwnProperty.call(LEVELS, name)) {
         this[name] = LEVELS[name].log;
       }

--- a/src/RegistrationManagement.js
+++ b/src/RegistrationManagement.js
@@ -1,14 +1,8 @@
-const requireAll = require('require-all');
 const path = require('path');
-const _forEach = require('lodash.foreach');
-const _isFunction = require('lodash.isfunction');
-const _isObject = require('lodash.isobject');
+const requireAll = require('require-all');
 
+const Utils = require('./Utils');
 const fileFilterExpression = require('./FileFilterExpression');
-
-const hasOwnProp = function (source, propertyName) {
-  return Object.prototype.hasOwnProperty.call(source, propertyName);
-};
 
 module.exports = {
   registerFolder(rootDir, dir) {
@@ -21,13 +15,14 @@ module.exports = {
     return this;
   },
 
-  registerLibMap(libs) {
-    _forEach(libs, (value, name) => {
-      if (hasOwnProp(libs, name)) {
+  registerLibMap(libs = {}) {
+    const names = Object.keys(libs) || [];
+    names.forEach((name) => {
+      if (Utils.hasOwnProp(libs, name)) {
         const lib = libs[name];
-        if (_isFunction(lib)) {
+        if (Utils.isFunction(lib)) {
           this.addResolvableDependency(name, lib);
-        } else if (_isObject(lib)) {
+        } else if (Utils.isObject(lib)) {
           this.registerLibMap(lib);
         }
       }
@@ -35,14 +30,15 @@ module.exports = {
     return this;
   },
 
-  registerFolders(rootDir, dirs) {
-    _forEach(dirs, (dir) => this.registerFolder(rootDir, dir));
+  registerFolders(rootDir, dirs = []) {
+    dirs.forEach((dir) => this.registerFolder(rootDir, dir));
     return this;
   },
 
-  registerDependencies(dependencies) {
-    _forEach(dependencies, (value, name) => {
-      if (hasOwnProp(dependencies, name)) {
+  registerDependencies(dependencies = {}) {
+    const names = Object.keys(dependencies) || [];
+    names.forEach((name) => {
+      if (Utils.hasOwnProp(dependencies, name)) {
         const lib = dependencies[name];
         this.addDependency(name, lib);
       }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,0 +1,14 @@
+module.exports = {
+  hasOwnProp(source, propertyName) {
+    return Object.prototype.hasOwnProperty.call(source, propertyName);
+  },
+
+  isFunction(value) {
+    return typeof value === 'function';
+  },
+
+  isObject(value) {
+    const type = typeof value;
+    return value != null && (type === 'object' || type === 'function');
+  }
+};

--- a/test/unit/Utils.spec.js
+++ b/test/unit/Utils.spec.js
@@ -1,0 +1,48 @@
+const Utils = require('../../src/Utils');
+
+describe('Utils', function () {
+  describe('hasOwnProp', () => {
+    it('should return true if the source object has the specified property', () => {
+      const source = { name: 'John', age: 30 };
+      const propertyName = 'name';
+      const result = Utils.hasOwnProp(source, propertyName);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the source object does not have the specified property', () => {
+      const source = { name: 'John', age: 30 };
+      const propertyName = 'address';
+      const result = Utils.hasOwnProp(source, propertyName);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isFunction', () => {
+    it('should return true if the value is a function', () => {
+      const value = () => {};
+      const result = Utils.isFunction(value);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the value is not a function', () => {
+      const value = 'Hello, World!';
+      const result = Utils.isFunction(value);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isObject', () => {
+    it('should return true if the value is an object', () => {
+      const value = { name: 'John', age: 30 };
+      const result = Utils.isObject(value);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the value is not an object', () => {
+      const value = 'Hello, World!';
+      const result = Utils.isObject(value);
+      expect(result).toBe(false);
+    });
+  });
+
+});


### PR DESCRIPTION
Most of these lodash dependencies have a native replacement. The only reason they seem to have been used was to wrap the natives with safe checks and returns.

For example the use of `_forEach(list, () => ...)` is a safe version of:

```
(list || []).forEach((item) => ...);
```

Lodash protects against undefined, null. Others such as _.map also protect by returning an empty map so that chaining is safely allowed, some es6 doesn't allow native.